### PR TITLE
feat: [TASK-5] change mock file import functionality

### DIFF
--- a/src/components/pages/admin/PageProductImport/components/CSVFileImport.tsx
+++ b/src/components/pages/admin/PageProductImport/components/CSVFileImport.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import Typography from "@mui/material/Typography";
 import Box from "@mui/material/Box";
+import axios from "axios";
 
 type CSVFileImportProps = {
   url: string;
@@ -25,22 +26,25 @@ export default function CSVFileImport({ url, title }: CSVFileImportProps) {
   const uploadFile = async () => {
     console.log("uploadFile to", url);
 
-    // Get the presigned URL
-    // const response = await axios({
-    //   method: "GET",
-    //   url,
-    //   params: {
-    //     name: encodeURIComponent(file.name),
-    //   },
-    // });
-    // console.log("File to upload: ", file.name);
-    // console.log("Uploading to: ", response.data);
-    // const result = await fetch(response.data, {
-    //   method: "PUT",
-    //   body: file,
-    // });
-    // console.log("Result: ", result);
-    // setFile("");
+    if (!file) {
+      return;
+    }
+
+    const response = await axios({
+      method: "GET",
+      url,
+      params: {
+        name: encodeURIComponent(file.name),
+      },
+    });
+    console.log("File to upload: ", file.name);
+    console.log("Uploading to: ", response.data.signedUrl);
+    const result = await fetch(response.data.signedUrl, {
+      method: "PUT",
+      body: file,
+    });
+    console.log("Result: ", result);
+    setFile(undefined);
   };
   return (
     <Box>

--- a/src/constants/apiPaths.ts
+++ b/src/constants/apiPaths.ts
@@ -2,7 +2,8 @@ const API_PATHS = {
   product:
     "https://jpvt591yah.execute-api.eu-central-1.amazonaws.com/dev/v1/product-api",
   order: "https://.execute-api.eu-west-1.amazonaws.com/dev",
-  import: "https://.execute-api.eu-west-1.amazonaws.com/dev",
+  import:
+    "https://nakx85fecc.execute-api.eu-central-1.amazonaws.com/dev/v1/product-import",
   bff: "https://.execute-api.eu-west-1.amazonaws.com/dev",
   cart: "https://.execute-api.eu-west-1.amazonaws.com/dev",
 };


### PR DESCRIPTION
Task 5: https://github.com/EPAM-JS-Competency-center/cloud-development-course-initial/blob/main/5_integration_with_s3/task.md

https://d1734hp6l7byad.cloudfront.net/

What was done:
- change the mock import API endpoint with the real one